### PR TITLE
remove message formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,45 +14,33 @@ Go errors library.
 
 ## Message
 
-[`New`](https://pkg.go.dev/github.com/pierrre/errors#New) and [`Newf`](https://pkg.go.dev/github.com/pierrre/errors#Newf) functions create an error with a message and a stack.
+[`New()`](https://pkg.go.dev/github.com/pierrre/errors#New) creates an error with a message and a stack.
 
 ```go
 err := errors.New("error")
 ```
 
-```go
-err := errors.Newf("error %s", "foo")
-```
-
-[`Wrap`](https://pkg.go.dev/github.com/pierrre/errors#Wrap) and [`Wrapf`](https://pkg.go.dev/github.com/pierrre/errors#Wrapf) functions add a message to an error, and optionally add a stack if the error doesn't have one.
+[`Wrap()`](https://pkg.go.dev/github.com/pierrre/errors#Wrap) adds a message to an error, and optionally adds a stack if the error doesn't have one.
 
 ```go
 err = errors.Wrap(err, "message")
 ```
 
-```go
-err = errors.Wrapf(err, "message %d", 1)
-```
-
-[`Message`](https://pkg.go.dev/github.com/pierrre/errors#Message) and [`Messagef`](https://pkg.go.dev/github.com/pierrre/errors#Messagef) functions add a message to an error. Most applications should use [`Wrap`](https://pkg.go.dev/github.com/pierrre/errors#Wrap) and [`Wrapf`](https://pkg.go.dev/github.com/pierrre/errors#Wrapf) instead, because they automatically add a stack.
+[`Message()`](https://pkg.go.dev/github.com/pierrre/errors#Message) adds a message to an error. Most applications should use [`Wrap()`](https://pkg.go.dev/github.com/pierrre/errors#Wrap) instead, because it automatically adds a stack.
 
 ```go
 err = errors.WithMessage(err, "message")
 ```
 
-```go
-err = errors.WithMessagef(err, "message %d", 1)
-```
-
 ## Stack trace
 
-[`Stack`](https://pkg.go.dev/github.com/pierrre/errors#Stack) function adds a stack to an error. This is only useful if the wrapped error has a stack from a different goroutine. Most applications should use [`Wrap`](https://pkg.go.dev/github.com/pierrre/errors#Wrap) and [`Wrapf`](https://pkg.go.dev/github.com/pierrre/errors#Wrapf) instead.
+[`Stack()`](https://pkg.go.dev/github.com/pierrre/errors#Stack) adds a stack to an error. This is only useful if the wrapped error has a stack from a different goroutine. Most applications should use [`Wrap()`](https://pkg.go.dev/github.com/pierrre/errors#Wrap) instead.
 
 ```go
 err = errors.Stack(err)
 ```
 
-[`StackFrames`](https://pkg.go.dev/github.com/pierrre/errors#StackFrames) function returns the [stack frames](https://pkg.go.dev/runtime#Frames) of the error.
+[`StackFrames()`](https://pkg.go.dev/github.com/pierrre/errors#StackFrames) returns the [stack frames](https://pkg.go.dev/runtime#Frames) of the error.
 
 ```go
 frames := errors.StackFrames(err)
@@ -63,7 +51,7 @@ frames := errors.StackFrames(err)
 The error verbose message shows additional information about the error.
 Wrapping functions may provide a verbose message (stack, tag, value, etc.)
 
-The [`Verbose`](https://pkg.go.dev/github.com/pierrre/errors#Verbose)/[`VerboseString`](https://pkg.go.dev/github.com/pierrre/errors#VerboseString)/[`VerboseFormatter`](https://pkg.go.dev/github.com/pierrre/errors#VerboseFormatter) functions write/return/format the error verbose message.
+The [`Verbose()`](https://pkg.go.dev/github.com/pierrre/errors#Verbose)/[`VerboseString()`](https://pkg.go.dev/github.com/pierrre/errors#VerboseString)/[`VerboseFormatter()`](https://pkg.go.dev/github.com/pierrre/errors#VerboseFormatter) write/return/format the error verbose message.
 
 The first line is the error's message.
 The following lines are the verbose message of the error chain.

--- a/message.go
+++ b/message.go
@@ -9,6 +9,8 @@ import (
 // The error message is "<msg>: <err>".
 //
 // If the given message is empty, the returned error is the given error.
+//
+// // Use fmt.Sprintf() to format the message.
 func Message(err error, msg string) error {
 	if err == nil {
 		return nil
@@ -20,11 +22,6 @@ func Message(err error, msg string) error {
 		error: err,
 		msg:   msg,
 	}
-}
-
-// Messagef adds a formatted message to an error.
-func Messagef(err error, format string, args ...any) error {
-	return Message(err, fmt.Sprintf(format, args...))
 }
 
 type message struct {

--- a/message_test.go
+++ b/message_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestMessage(t *testing.T) {
 	err := New("error")
-	err = Messagef(err, "%s", "test")
+	err = Message(err, "test")
 	s := err.Error()
 	expected := "test: error"
 	if s != expected {
@@ -37,11 +37,4 @@ func ExampleMessage() {
 	err = Message(err, "message")
 	fmt.Println(err)
 	// Output: message: error
-}
-
-func ExampleMessagef() {
-	err := New("error")
-	err = Messagef(err, "message %s", "formatted")
-	fmt.Println(err)
-	// Output: message formatted: error
 }

--- a/new.go
+++ b/new.go
@@ -1,17 +1,9 @@
 package errors
 
-import (
-	"fmt"
-)
-
 // New returns a new error with a message and a stack.
+//
+// Use fmt.Sprintf() to format the message.
 func New(msg string) error {
-	return newError(msg)
-}
-
-// Newf returns a new error with a formatted message and a stack.
-func Newf(format string, args ...any) error {
-	msg := fmt.Sprintf(format, args...)
 	return newError(msg)
 }
 

--- a/new_test.go
+++ b/new_test.go
@@ -23,22 +23,3 @@ func ExampleNew() {
 	fmt.Println(err)
 	// Output: error
 }
-
-func TestNewf(t *testing.T) {
-	err := Newf("%s", "error")
-	s := err.Error()
-	expected := "error"
-	if s != expected {
-		t.Fatalf("unexpected message: got %q, want %q", s, expected)
-	}
-	sfs := StackFrames(err)
-	if len(sfs) != 1 {
-		t.Fatalf("unexpected length: got %d, want %d", len(sfs), 1)
-	}
-}
-
-func ExampleNewf() {
-	err := Newf("error %s", "formatted")
-	fmt.Println(err)
-	// Output: error formatted
-}

--- a/wrap.go
+++ b/wrap.go
@@ -8,10 +8,3 @@ func Wrap(err error, msg string) error {
 	err = ensureStack(err, 2)
 	return err
 }
-
-// Wrapf adds a formatted message to an error, and optionnally add a stack if it doesn't have one.
-func Wrapf(err error, format string, args ...any) error {
-	err = Messagef(err, format, args...)
-	err = ensureStack(err, 2)
-	return err
-}

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -7,10 +7,9 @@ import (
 
 func TestWrap(t *testing.T) {
 	err := newBase("error")
-	err = Wrap(err, "test1")
-	err = Wrapf(err, "%s", "test2")
+	err = Wrap(err, "test")
 	s := err.Error()
-	expected := "test2: test1: error"
+	expected := "test: error"
 	if s != expected {
 		t.Fatalf("unexpected message: got %q, want %q", s, expected)
 	}
@@ -25,11 +24,4 @@ func ExampleWrap() {
 	err = Wrap(err, "wrap")
 	fmt.Println(err)
 	// Output: wrap: error
-}
-
-func ExampleWrapf() {
-	err := New("error")
-	err = Wrapf(err, "wrap %s", "formatted")
-	fmt.Println(err)
-	// Output: wrap formatted: error
 }


### PR DESCRIPTION
Callers should use fmt.Sprintf().
This makes the library more "orthogonal".