### PR TITLE
optimize

### DIFF
--- a/errbase/errbase.go
+++ b/errbase/errbase.go
@@ -3,28 +3,20 @@ package errbase
 
 import (
 	"fmt"
-)
 
-type base struct {
-	msg string
-}
+	std_errors "errors"
+)
 
 // New creates a new error with the given message.
 //
 // It can be used as a "sentinel" error.
 func New(msg string) error {
-	return &base{
-		msg: msg,
-	}
+	return std_errors.New(msg)
 }
 
 // Newf creates a new error with the given formatted message.
 //
-// It doesn't support the %w verb.
+// It supports the %w verb.
 func Newf(format string, args ...any) error {
-	return New(fmt.Sprintf(format, args...))
-}
-
-func (err *base) Error() string {
-	return err.msg
+	return fmt.Errorf(format, args...)
 }

--- a/errmsg/errmsg.go
+++ b/errmsg/errmsg.go
@@ -19,7 +19,7 @@ func Wrap(err error, msg string) error {
 	}
 	return &message{
 		error: err,
-		msg:   msg,
+		msg:   msg + ": " + err.Error(),
 	}
 }
 
@@ -42,5 +42,5 @@ func (err *message) Unwrap() error {
 }
 
 func (err *message) Error() string {
-	return err.msg + ": " + err.error.Error()
+	return err.msg
 }

--- a/errmsg/errmsg_test.go
+++ b/errmsg/errmsg_test.go
@@ -52,7 +52,7 @@ func TestWrapAllocs(t *testing.T) {
 	var res error
 	assert.AllocsPerRun(t, 100, func() {
 		res = Wrap(err, "test")
-	}, 1)
+	}, 2)
 	runtime.KeepAlive(res)
 }
 
@@ -61,7 +61,7 @@ func TestWrapfAllocs(t *testing.T) {
 	var res error
 	assert.AllocsPerRun(t, 100, func() {
 		res = Wrapf(err, "test %d", 1)
-	}, 2)
+	}, 3)
 	runtime.KeepAlive(res)
 }
 
@@ -71,7 +71,7 @@ func TestErrorAllocs(t *testing.T) {
 	var res string
 	assert.AllocsPerRun(t, 100, func() {
 		res = err.Error()
-	}, 1)
+	}, 0)
 	runtime.KeepAlive(res)
 }
 

--- a/errors.go
+++ b/errors.go
@@ -20,7 +20,7 @@ func New(msg string) error {
 
 // Newf returns a new error with a formatted message and a stack.
 //
-// It doesn't support the %w verb.
+// It supports the %w verb.
 func Newf(format string, args ...any) error {
 	err := errbase.Newf(format, args...)
 	err = errstack.WrapSkip(err, 1)

--- a/errstack/errstack.go
+++ b/errstack/errstack.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"sync"
 
+	"github.com/pierrre/errors/errbase"
 	"github.com/pierrre/go-libs/bufpool"
 	"github.com/pierrre/go-libs/strconvio"
 )
@@ -53,6 +54,10 @@ type stack struct {
 
 func (err *stack) Unwrap() error {
 	return err.error
+}
+
+func (err *stack) Is(target error) bool {
+	return target == err || target == errHas
 }
 
 var bufferPool = bufpool.Pool{}
@@ -125,11 +130,10 @@ func stackFramesNext(err error, pfss *[]*runtime.Frames) error {
 	return nil
 }
 
+var errHas = errbase.New("stack")
+
 func has(err error) bool {
-	var werr interface {
-		RuntimeStackFrames() *runtime.Frames
-	}
-	return std_errors.As(err, &werr)
+	return std_errors.Is(err, errHas)
 }
 
 const callersMaxLength = 1 << 16

--- a/errstack/errstack_test.go
+++ b/errstack/errstack_test.go
@@ -101,7 +101,7 @@ func TestEnsureAllocs(t *testing.T) {
 	var res error
 	assert.AllocsPerRun(t, 100, func() {
 		res = Ensure(err)
-	}, 1)
+	}, 0)
 	runtime.KeepAlive(res)
 }
 

--- a/integrationtest/integrationtest_test.go
+++ b/integrationtest/integrationtest_test.go
@@ -75,14 +75,14 @@ func TestErrorAllocs(t *testing.T) {
 	var res string
 	assert.AllocsPerRun(t, 100, func() {
 		res = errTest.Error()
-	}, 4)
+	}, 0)
 	runtime.KeepAlive(res)
 }
 
 func TestVerboseAllocs(t *testing.T) {
 	assert.AllocsPerRun(t, 100, func() {
 		errverbose.Write(io.Discard, errTest)
-	}, 11)
+	}, 7)
 }
 
 func TestStackAllocs(t *testing.T) {


### PR DESCRIPTION
- errbase functions are now calling std_errors.New() and fmt.Errorf()
- errmsg is now building the full error message when the error is wrapped, so returning the error message doesn't allocate memory
- errbase.Newf() and errors.Newf() now support the %w verb
- errstack.Ensure now doesn't allocate memory to check if the error already has a stack