### PR TITLE
errverbose: use a "write" function instead of returning a string

### DIFF
--- a/errignore/errignore.go
+++ b/errignore/errignore.go
@@ -2,6 +2,8 @@
 package errignore
 
 import (
+	"io"
+
 	"github.com/pierrre/errors"
 )
 
@@ -25,8 +27,8 @@ func (err *ignore) Unwrap() error {
 	return err.error
 }
 
-func (err *ignore) ErrorVerbose() string {
-	return "ignored"
+func (err *ignore) ErrorVerbose(w io.Writer) {
+	_, _ = io.WriteString(w, "ignored")
 }
 
 func (err *ignore) Ignored() bool {

--- a/errignore/errignore_test.go
+++ b/errignore/errignore_test.go
@@ -2,7 +2,9 @@ package errignore_test
 
 import (
 	"fmt"
+	"io"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/pierrre/assert"
@@ -54,7 +56,9 @@ func TestVerbose(t *testing.T) {
 	err = Wrap(err)
 	var v errverbose.Interface
 	assert.ErrorAs(t, err, &v)
-	s := v.ErrorVerbose()
+	sb := new(strings.Builder)
+	v.ErrorVerbose(sb)
+	s := sb.String()
 	assert.Equal(t, s, "ignored")
 }
 
@@ -89,11 +93,9 @@ func TestVerboseAllocs(t *testing.T) {
 	err = Wrap(err)
 	var v errverbose.Interface
 	assert.ErrorAs(t, err, &v)
-	var res string
 	assert.AllocsPerRun(t, 100, func() {
-		res = v.ErrorVerbose()
+		v.ErrorVerbose(io.Discard)
 	}, 0)
-	runtime.KeepAlive(res)
 }
 
 func BenchmarkWrap(b *testing.B) {
@@ -120,9 +122,7 @@ func BenchmarkVerbose(b *testing.B) {
 	err = Wrap(err)
 	var v errverbose.Interface
 	assert.ErrorAs(b, err, &v)
-	var res string
 	for i := 0; i < b.N; i++ {
-		res = v.ErrorVerbose()
+		v.ErrorVerbose(io.Discard)
 	}
-	runtime.KeepAlive(res)
 }

--- a/errstack/errstack_test.go
+++ b/errstack/errstack_test.go
@@ -2,7 +2,9 @@ package errstack_test
 
 import (
 	"fmt"
+	"io"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/pierrre/assert"
@@ -56,7 +58,9 @@ func TestVerbose(t *testing.T) {
 	err = Wrap(err)
 	var v errverbose.Interface
 	assert.ErrorAs(t, err, &v)
-	s := v.ErrorVerbose()
+	sb := new(strings.Builder)
+	v.ErrorVerbose(sb)
+	s := sb.String()
 	assert.RegexpMatch(t, `^stack\n(\t.+ .+:\d+\n)+$`, s)
 }
 
@@ -120,11 +124,9 @@ func TestVerboseAllocs(t *testing.T) {
 	err = Wrap(err)
 	var v errverbose.Interface
 	assert.ErrorAs(t, err, &v)
-	var res string
 	assert.AllocsPerRun(t, 100, func() {
-		res = v.ErrorVerbose()
-	}, 2)
-	runtime.KeepAlive(res)
+		v.ErrorVerbose(io.Discard)
+	}, 1)
 }
 
 func BenchmarkWrap(b *testing.B) {
@@ -161,9 +163,7 @@ func BenchmarkVerbose(b *testing.B) {
 	err = Wrap(err)
 	var v errverbose.Interface
 	assert.ErrorAs(b, err, &v)
-	var res string
 	for i := 0; i < b.N; i++ {
-		res = v.ErrorVerbose()
+		v.ErrorVerbose(io.Discard)
 	}
-	runtime.KeepAlive(res)
 }

--- a/errtag/errtag.go
+++ b/errtag/errtag.go
@@ -2,6 +2,7 @@
 package errtag
 
 import (
+	"io"
 	"strconv"
 
 	"github.com/pierrre/errors/erriter"
@@ -53,8 +54,11 @@ func (err *tag) Unwrap() error {
 	return err.error
 }
 
-func (err *tag) ErrorVerbose() string {
-	return "tag " + err.key + " = " + err.val
+func (err *tag) ErrorVerbose(w io.Writer) {
+	_, _ = io.WriteString(w, "tag ")
+	_, _ = io.WriteString(w, err.key)
+	_, _ = io.WriteString(w, " = ")
+	_, _ = io.WriteString(w, err.val)
 }
 
 func (err *tag) Tag() (key string, val string) {

--- a/errtag/errtag_test.go
+++ b/errtag/errtag_test.go
@@ -2,7 +2,9 @@ package errtag_test
 
 import (
 	"fmt"
+	"io"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/pierrre/assert"
@@ -102,7 +104,9 @@ func TestVerbose(t *testing.T) {
 	err = Wrap(err, "foo", "bar")
 	var v errverbose.Interface
 	assert.ErrorAs(t, err, &v)
-	s := v.ErrorVerbose()
+	sb := new(strings.Builder)
+	v.ErrorVerbose(sb)
+	s := sb.String()
 	assert.Equal(t, s, "tag foo = bar")
 }
 
@@ -190,11 +194,9 @@ func TestVerboseAllocs(t *testing.T) {
 	err = Wrap(err, "foo", "bar")
 	var v errverbose.Interface
 	assert.ErrorAs(t, err, &v)
-	var res string
 	assert.AllocsPerRun(t, 100, func() {
-		res = v.ErrorVerbose()
-	}, 1)
-	runtime.KeepAlive(res)
+		v.ErrorVerbose(io.Discard)
+	}, 0)
 }
 
 func BenchmarkWrap(b *testing.B) {
@@ -257,9 +259,7 @@ func BenchmarkVerbose(b *testing.B) {
 	err = Wrap(err, "foo", "bar")
 	var v errverbose.Interface
 	assert.ErrorAs(b, err, &v)
-	var res string
 	for i := 0; i < b.N; i++ {
-		res = v.ErrorVerbose()
+		v.ErrorVerbose(io.Discard)
 	}
-	runtime.KeepAlive(res)
 }

--- a/errtmp/errtmp.go
+++ b/errtmp/errtmp.go
@@ -2,9 +2,10 @@
 package errtmp
 
 import (
-	"strconv"
+	"io"
 
 	"github.com/pierrre/errors"
+	"github.com/pierrre/go-libs/strconvio"
 )
 
 // Wrap marks an errors as temporary.
@@ -29,8 +30,9 @@ func (err *temporary) Unwrap() error {
 	return err.error
 }
 
-func (err *temporary) ErrorVerbose() string {
-	return "temporary = " + strconv.FormatBool(err.tmp)
+func (err *temporary) ErrorVerbose(w io.Writer) {
+	_, _ = io.WriteString(w, "temporary = ")
+	_, _ = strconvio.WriteBool(w, err.tmp)
 }
 
 func (err *temporary) Temporary() bool {

--- a/errtmp/errtmp_test.go
+++ b/errtmp/errtmp_test.go
@@ -2,7 +2,9 @@ package errtmp_test
 
 import (
 	"fmt"
+	"io"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/pierrre/assert"
@@ -61,7 +63,9 @@ func TestVerbose(t *testing.T) {
 	err = Wrap(err, true)
 	var v errverbose.Interface
 	assert.ErrorAs(t, err, &v)
-	s := v.ErrorVerbose()
+	sb := new(strings.Builder)
+	v.ErrorVerbose(sb)
+	s := sb.String()
 	assert.Equal(t, s, "temporary = true")
 }
 
@@ -95,11 +99,9 @@ func TestVerboseAllocs(t *testing.T) {
 	err = Wrap(err, true)
 	var v errverbose.Interface
 	assert.ErrorAs(t, err, &v)
-	var res string
 	assert.AllocsPerRun(t, 100, func() {
-		res = v.ErrorVerbose()
-	}, 1)
-	runtime.KeepAlive(res)
+		v.ErrorVerbose(io.Discard)
+	}, 0)
 }
 
 func BenchmarkWrap(b *testing.B) {
@@ -126,9 +128,7 @@ func BenchmarkVerbose(b *testing.B) {
 	err = Wrap(err, true)
 	var v errverbose.Interface
 	assert.ErrorAs(b, err, &v)
-	var res string
 	for i := 0; i < b.N; i++ {
-		res = v.ErrorVerbose()
+		v.ErrorVerbose(io.Discard)
 	}
-	runtime.KeepAlive(res)
 }

--- a/errval/errval.go
+++ b/errval/errval.go
@@ -3,15 +3,16 @@ package errval
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/pierrre/errors/erriter"
 )
 
-// VerboseStringer returns the string representation of a value in a verbose message.
+// VerboseWriter writes the representation of a value in a verbose message.
 //
 // It can be changed in order to customize how values are formatted.
-var VerboseStringer = func(v any) string {
-	return fmt.Sprint(v)
+var VerboseWriter = func(w io.Writer, v any) {
+	_, _ = fmt.Fprint(w, v)
 }
 
 // Wrap adds a value to an error.
@@ -39,8 +40,11 @@ func (err *value) Unwrap() error {
 	return err.error
 }
 
-func (err *value) ErrorVerbose() string {
-	return "value " + err.key + " = " + VerboseStringer(err.val)
+func (err *value) ErrorVerbose(w io.Writer) {
+	_, _ = io.WriteString(w, "value ")
+	_, _ = io.WriteString(w, err.key)
+	_, _ = io.WriteString(w, " = ")
+	VerboseWriter(w, err.val)
 }
 
 func (err *value) Value() (key string, val any) {

--- a/errval/errval_test.go
+++ b/errval/errval_test.go
@@ -2,7 +2,9 @@ package errval_test
 
 import (
 	"fmt"
+	"io"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/pierrre/assert"
@@ -66,7 +68,9 @@ func TestVerbose(t *testing.T) {
 	err = Wrap(err, "foo", "bar")
 	var v errverbose.Interface
 	assert.ErrorAs(t, err, &v)
-	s := v.ErrorVerbose()
+	sb := new(strings.Builder)
+	v.ErrorVerbose(sb)
+	s := sb.String()
 	assert.Equal(t, s, "value foo = bar")
 }
 
@@ -118,11 +122,9 @@ func TestVerboseAllocs(t *testing.T) {
 	err = Wrap(err, "foo", "bar")
 	var v errverbose.Interface
 	assert.ErrorAs(t, err, &v)
-	var res string
 	assert.AllocsPerRun(t, 100, func() {
-		res = v.ErrorVerbose()
-	}, 2)
-	runtime.KeepAlive(res)
+		v.ErrorVerbose(io.Discard)
+	}, 0)
 }
 
 func BenchmarkWrap(b *testing.B) {
@@ -149,9 +151,7 @@ func BenchmarkVerbose(b *testing.B) {
 	err = Wrap(err, "foo", "bar")
 	var v errverbose.Interface
 	assert.ErrorAs(b, err, &v)
-	var res string
 	for i := 0; i < b.N; i++ {
-		res = v.ErrorVerbose()
+		v.ErrorVerbose(io.Discard)
 	}
-	runtime.KeepAlive(res)
 }

--- a/errverbose/errverbose.go
+++ b/errverbose/errverbose.go
@@ -15,9 +15,9 @@ import (
 //
 // It is used by Write().
 type Interface interface {
-	// ErrorVerbose returns the error verbose message.
-	// It must only return the verbose message of the error, not the error chain.
-	ErrorVerbose() string
+	// ErrorVerbose writes the error verbose message.
+	// It must only write the verbose message of the error, not the error chain.
+	ErrorVerbose(io.Writer)
 }
 
 var depthPool = sync.Pool{
@@ -48,8 +48,7 @@ func write(w io.Writer, err error, depth []int) {
 	for ; err != nil; err = writeNext(w, err, depth) {
 		v, ok := err.(Interface) //nolint:errorlint // We want to compare the current error.
 		if ok {
-			s := v.ErrorVerbose()
-			_, _ = io.WriteString(w, s)
+			v.ErrorVerbose(w)
 			_, _ = io.WriteString(w, "\n")
 		}
 	}

--- a/errverbose/errverbose_test.go
+++ b/errverbose/errverbose_test.go
@@ -44,8 +44,8 @@ type testVerbose struct {
 	error
 }
 
-func (v *testVerbose) ErrorVerbose() string {
-	return "verbose"
+func (v *testVerbose) ErrorVerbose(w io.Writer) {
+	_, _ = io.WriteString(w, "verbose")
 }
 
 func (v *testVerbose) Unwrap() error {

--- a/ext/pierrrepretty/pierrrepretty.go
+++ b/ext/pierrrepretty/pierrrepretty.go
@@ -10,7 +10,7 @@ import (
 //
 // It sets errval.VerboseStringer with pretty.Config.String.
 func Configure(config *pretty.Config) {
-	errval.VerboseStringer = config.String
+	errval.VerboseWriter = config.Write
 }
 
 // ConfigureDefault calls Configure() with pretty.DefaultConfig.

--- a/ext/pierrrepretty/pierrrepretty_test.go
+++ b/ext/pierrrepretty/pierrrepretty_test.go
@@ -1,6 +1,7 @@
 package pierrrepretty
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/pierrre/assert"
@@ -18,6 +19,8 @@ func Test(t *testing.T) {
 	err = errval.Wrap(err, "foo", "bar")
 	var v errverbose.Interface
 	assert.ErrorAs(t, err, &v)
-	s := v.ErrorVerbose()
+	sb := new(strings.Builder)
+	v.ErrorVerbose(sb)
+	s := sb.String()
 	assert.Equal(t, s, "value foo = (string) (len=3) \"bar\"")
 }

--- a/integrationtest/integrationtest_test.go
+++ b/integrationtest/integrationtest_test.go
@@ -97,7 +97,7 @@ func TestVerboseAllocs(t *testing.T) {
 	err := newTestError()
 	assert.AllocsPerRun(t, 100, func() {
 		errverbose.Write(io.Discard, err)
-	}, 7)
+	}, 2)
 }
 
 func TestStackAllocs(t *testing.T) {


### PR DESCRIPTION
It should improve the performance.