### PR TITLE
docs(errtmp): document Is default behavior

### DIFF
--- a/errtmp/errtmp.go
+++ b/errtmp/errtmp.go
@@ -42,7 +42,9 @@ func (err *temporary) Temporary() bool {
 
 // Is returns true if an error is temporary, false otherwise.
 //
-// By default, an error is temporary.
+// By default, an error is considered temporary.
+// This is the opposite of the usual convention where an error that does not implement a Temporary() bool method is considered not temporary.
+// To explicitly mark an error as not temporary, wrap it with [Wrap] and the value false.
 func Is(err error) bool {
 	var werr interface {
 		Temporary() bool


### PR DESCRIPTION
The `Is` function returns `true` for errors that do not implement a `Temporary() bool` method, so an unmarked error is considered temporary by default.

This inverts the usual convention (e.g. the `net.Error.Temporary` pattern), where the absence of a `Temporary()` method means the error is not temporary.

The default is left unchanged (changing it would be a breaking API change), but the behavior is now documented explicitly on `Is`, and the doc points to `Wrap(err, false)` as the way to mark an error as not temporary.

Refs: errtmp/errtmp.go:48-57