### PR TITLE
refactor: extract errtag/errval Get map-build loop to erriter.FirstKeys

### DIFF
--- a/erriter/erriter.go
+++ b/erriter/erriter.go
@@ -46,3 +46,15 @@ func Unwrap(err error) ([]error, error) {
 	}
 	return nil, nil
 }
+
+// FirstKeys returns a map built from seq, where the first value is kept for each key.
+func FirstKeys[V any](seq iter.Seq2[string, V]) map[string]V {
+	m := make(map[string]V)
+	for k, v := range seq {
+		if _, ok := m[k]; ok {
+			continue
+		}
+		m[k] = v
+	}
+	return m
+}

--- a/erriter/erriter_test.go
+++ b/erriter/erriter_test.go
@@ -47,6 +47,27 @@ func TestAllAllocs(t *testing.T) {
 	}, 0)
 }
 
+func TestFirstKeys(t *testing.T) {
+	seq := func(yield func(string, int) bool) {
+		yield("a", 1)
+		yield("b", 2)
+		yield("a", 3)
+		yield("c", 4)
+	}
+	m := erriter.FirstKeys(seq)
+	assert.MapEqual(t, m, map[string]int{
+		"a": 1,
+		"b": 2,
+		"c": 4,
+	})
+}
+
+func TestFirstKeysEmpty(t *testing.T) {
+	seq := func(yield func(string, int) bool) {}
+	m := erriter.FirstKeys(seq)
+	assert.MapEmpty(t, m)
+}
+
 func BenchmarkAll(b *testing.B) {
 	err := newTestError()
 	for b.Loop() {

--- a/errtag/errtag.go
+++ b/errtag/errtag.go
@@ -87,13 +87,5 @@ func All(err error) iter.Seq2[string, string] {
 
 // Get returns the tags added to an error.
 func Get(err error) map[string]string {
-	tags := make(map[string]string)
-	for k, v := range All(err) {
-		_, ok := tags[k]
-		if ok {
-			continue
-		}
-		tags[k] = v
-	}
-	return tags
+	return erriter.FirstKeys(All(err))
 }

--- a/errval/errval.go
+++ b/errval/errval.go
@@ -82,13 +82,5 @@ func All(err error) iter.Seq2[string, any] {
 
 // Get returns the values added to an error.
 func Get(err error) map[string]any {
-	vals := make(map[string]any)
-	for k, v := range All(err) {
-		_, ok := vals[k]
-		if ok {
-			continue
-		}
-		vals[k] = v
-	}
-	return vals
+	return erriter.FirstKeys(All(err))
 }


### PR DESCRIPTION
## Summary

`errtag.Get` and `errval.Get` both implemented the same "first key wins" map-build loop over their respective `All(...)` iterators, differing only in the value type (`string` vs `any`).

## Changes

- Added `erriter.FirstKeys[V any](seq iter.Seq2[string, V]) map[string]V`, a generic helper that builds a map from a `iter.Seq2[string, V]`, keeping the first value encountered for each key.
- Rewrote `errtag.Get` and `errval.Get` to delegate to it.

## Rationale

- Both packages already depend on `erriter`, so this adds no new dependency edges and keeps the public `Get` signatures unchanged (additive API only).
- The new helper is generic, so it preserves the exact behavior of both call sites without type-specific duplication.

## Test coverage

- Added `erriter.TestFirstKeys` (distinct keys + duplicate-key first-wins branch) and `erriter.TestFirstKeysEmpty` (zero-iteration case).
- Existing `errtag`/`errval` tests continue to cover the integration (`TestOverWrite`, `TestJoin`, `TestGetAllocs`).
- `go test -coverprofile ./...` reports 100.0% across all packages; `FirstKeys`, `errtag.Get`, and `errval.Get` are fully covered.
- The allocation count of `Get` is unchanged (still 2 allocs — the `All` closure + the map), confirmed by the existing `TestGetAllocs` tests.
- `make all` passes (build + test + lint, 0 issues).