### PR TITLE
feat(errval): add GetValue

### DIFF
--- a/errval/errval.go
+++ b/errval/errval.go
@@ -84,3 +84,15 @@ func All(err error) iter.Seq2[string, any] {
 func Get(err error) map[string]any {
 	return erriter.FirstKeys(All(err))
 }
+
+// GetValue returns the first value added to an error for the given key.
+//
+// It returns false if the key is not found.
+func GetValue(err error, key string) (any, bool) {
+	for k, v := range All(err) {
+		if k == key {
+			return v, true
+		}
+	}
+	return nil, false
+}

--- a/errval/errval_test.go
+++ b/errval/errval_test.go
@@ -136,6 +136,92 @@ func TestVerboseAllocs(t *testing.T) {
 	}, 0)
 }
 
+func ExampleGetValue() {
+	err := errbase.New("error")
+	err = Wrap(err, "foo", "bar")
+	val, ok := GetValue(err, "foo")
+	fmt.Println(ok, val)
+	// Output: true bar
+}
+
+func TestGetValue(t *testing.T) {
+	err := errbase.New("error")
+	err = Wrap(err, "foo", "bar")
+	val, ok := GetValue(err, "foo")
+	assert.True(t, ok)
+	assert.Equal(t, val, "bar")
+}
+
+func TestGetValueNotFound(t *testing.T) {
+	err := errbase.New("error")
+	err = Wrap(err, "foo", "bar")
+	val, ok := GetValue(err, "baz")
+	assert.False(t, ok)
+	assert.Equal(t, val, nil)
+}
+
+func TestGetValueOverWrite(t *testing.T) {
+	err := errbase.New("error")
+	err = Wrap(err, "test", 1)
+	err = Wrap(err, "test", 2)
+	val, ok := GetValue(err, "test")
+	assert.True(t, ok)
+	assert.Equal(t, val, 2)
+}
+
+func TestGetValueEmpty(t *testing.T) {
+	err := errbase.New("error")
+	val, ok := GetValue(err, "foo")
+	assert.False(t, ok)
+	assert.Equal(t, val, nil)
+}
+
+func TestGetValueNil(t *testing.T) {
+	val, ok := GetValue(nil, "foo")
+	assert.False(t, ok)
+	assert.Equal(t, val, nil)
+}
+
+func TestGetValueJoin(t *testing.T) {
+	err := Wrap(
+		errors.Join(
+			Wrap(
+				errors.New("error"),
+				"foo",
+				"baz",
+			),
+			Wrap(
+				errors.New("error"),
+				"aaa",
+				"bbb",
+			),
+		),
+		"foo",
+		"bar",
+	)
+	val, ok := GetValue(err, "foo")
+	assert.True(t, ok)
+	assert.Equal(t, val, "bar")
+	val, ok = GetValue(err, "aaa")
+	assert.True(t, ok)
+	assert.Equal(t, val, "bbb")
+	val, ok = GetValue(err, "missing")
+	assert.False(t, ok)
+	assert.Equal(t, val, nil)
+}
+
+func TestGetValueAllocs(t *testing.T) {
+	err := errbase.New("error")
+	err = Wrap(err, "foo", "bar")
+	var res any
+	var ok bool
+	assert.AllocsPerRun(t, 100, func() {
+		res, ok = GetValue(err, "foo")
+	}, 0)
+	testSink = res
+	testSink = ok
+}
+
 func BenchmarkWrap(b *testing.B) {
 	err := errbase.New("error")
 	for b.Loop() {
@@ -148,6 +234,14 @@ func BenchmarkGet(b *testing.B) {
 	err = Wrap(err, "foo", "bar")
 	for b.Loop() {
 		_ = Get(err)
+	}
+}
+
+func BenchmarkGetValue(b *testing.B) {
+	err := errbase.New("error")
+	err = Wrap(err, "foo", "bar")
+	for b.Loop() {
+		_, _ = GetValue(err, "foo")
 	}
 }
 


### PR DESCRIPTION
Add a `GetValue(err, key) (any, bool)` helper that returns the first value added to an error for a given key, with a `bool` indicating whether the key was found.

## Motivation

`errval.Get` returns a full `map[string]any`, which allocates a map even when only a single value is needed. `GetValue` iterates the error tree and returns the first match for the key, allocating nothing.

## Approach

- `GetValue` reuses the existing `All` iterator and returns the first value whose key matches.
- Semantics are consistent with `Get`: the first occurrence of a key wins (the outermost wrapper is yielded first by `erriter.All`).
- Returns `nil, false` when the key is absent, when the error has no values, or when `err` is `nil`.

## Test coverage

Added tests for: found value, not-found, overwrite (first-wins), empty error, `nil` error, joined errors, and a 0-allocation assertion (`TestGetValueAllocs`). Also added an `ExampleGetValue` and a `BenchmarkGetValue`.

`errval` package coverage: 100%.