### PR TITLE
test(erriter): lock traversal order for mixed Join+Wrap chains

### DIFF
--- a/erriter/erriter_test.go
+++ b/erriter/erriter_test.go
@@ -1,6 +1,7 @@
 package erriter_test
 
 import (
+	std_errors "errors"
 	"testing"
 
 	"github.com/pierrre/assert"
@@ -37,6 +38,22 @@ func TestAllStop(t *testing.T) {
 		}
 	}
 	assert.Equal(t, count, 4)
+}
+
+func TestAllTraversalOrder(t *testing.T) {
+	a := errbase.New("a")
+	b := errbase.New("b")
+	c := errbase.New("c")
+	j1 := std_errors.Join(a, b)
+	w1 := errmsg.Wrap(j1, "w1")
+	w2 := errmsg.Wrap(c, "w2")
+	j0 := std_errors.Join(w1, w2)
+	err := errmsg.Wrap(j0, "w0")
+	var got []error
+	for e := range erriter.All(err) {
+		got = append(got, e)
+	}
+	assert.SliceEqual(t, got, []error{err, j0, w1, j1, a, b, w2, c})
 }
 
 func TestAllAllocs(t *testing.T) {


### PR DESCRIPTION
Add `TestAllTraversalOrder`, which builds a tree that interleaves linear wraps (`errmsg.Wrap`, `Unwrap() error`) and multi wraps (`std_errors.Join`, `Unwrap() []error`) at multiple depths:

w0 -> j0 -> [w1 -> j1 -> [a, b], w2 -> c]

It collects the errors yielded by `erriter.All` and asserts the exact order by pointer identity:

[w0, j0, w1, j1, a, b, w2, c]

This locks the pre-order DFS that `iterFunc` performs: it follows the linear `Unwrap() error` chain depth-first, and when it reaches a `Unwrap() []error` node it recurses into each child in order before continuing. The existing `TestAll` only asserts the node count (5); this guards the traversal order against refactors of `iterFunc` (erriter/erriter.go:17-33).

`std_errors.Join` is used directly (rather than the repo `errors.Join`) so the test isolates `erriter`'s order logic from `errstack`'s stack-wrapper insertion, mirroring the approach in `errverbose` tests.