### PR TITLE
docs: add erriter and errverbose to README Extend section

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ See the provided packages as an example:
 - [`errval`](https://pkg.go.dev/github.com/pierrre/errors/errval): add a value to an error
 - [`errignore`](https://pkg.go.dev/github.com/pierrre/errors/errignore): mark an error as ignored
 - [`errtmp`](https://pkg.go.dev/github.com/pierrre/errors/errtmp): mark an error as temporary
+- [`erriter`](https://pkg.go.dev/github.com/pierrre/errors/erriter): iterate over an error tree
+- [`errverbose`](https://pkg.go.dev/github.com/pierrre/errors/errverbose): manage error verbose messages
 
 ## Migrate from the std `errors` package
 


### PR DESCRIPTION
The README "Extend" section lists the provided sub-packages but omits `erriter` (error-tree iteration API) and `errverbose` (verbose message utilities).

This adds both to the list, following the existing format.